### PR TITLE
Add Scope Setting

### DIFF
--- a/AppConfigSettingsTests/ScopeTests.cs
+++ b/AppConfigSettingsTests/ScopeTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Configuration;
+using System.IO;
+using AppConfigSettings;
+using AppConfigSettings.Enum;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AppConfigSettingsTests
+{
+    [TestClass]
+    public class ScopeTests : TestBase
+    {
+        private const string JSON = "FromJson";
+        private const string APP = "FromApp";
+        private const string ENV = "FromEnv";
+
+        private const string Test1Key = "Test1";
+        private const string Test2Key = "Test2";
+
+        private const string JSON_CONFIG =
+            "{\r\n  \"Test1\": \"FromJson\",\r\n  \"Test2\": \"FromJson\"\r\n}";
+
+        private static ConfigSetting<string> test1 = new ConfigSetting<string>("Test1", default);
+        private static ConfigSetting<string> test2 = new ConfigSetting<string>("Test2", default);
+
+        private readonly NameValueCollection appConfig = new NameValueCollection
+        {
+            { Test1Key, APP }, { Test2Key, APP },
+        };
+
+        private readonly List<string> filePaths = new List<string>();
+
+        [TestInitialize]
+        public void Settings_InitTest()
+        {
+            Environment.SetEnvironmentVariable(Test1Key, ENV);
+            Environment.SetEnvironmentVariable(Test2Key, ENV);
+
+            filePaths.Add(CreateFile($"{APP_SETTINGS_NAME}.{APP_SETTINGS_EXT}",
+                                     JSON_CONFIG,
+                                     Directory.GetCurrentDirectory()));
+        }
+
+        [TestCleanup]
+        public void Settings_CleanTest()
+        {
+            Environment.SetEnvironmentVariable(Test1Key, null);
+            Environment.SetEnvironmentVariable(Test2Key, null);
+
+            Settings.SetAppSettings(ConfigurationManager.AppSettings);
+            filePaths.ForEach(DeleteFile);
+        }
+
+        [TestMethod]
+        public void Scope_ShouldBe_JSON_APP_ENV()
+        {
+            test1 = new ConfigSetting<string>(Test1Key, default) { AppConfig = appConfig, };
+            test2 = new ConfigSetting<string>(Test2Key, default) { AppConfig = appConfig, };
+
+            test1.Get().Should().Be(JSON);
+            test2.Get().Should().Be(JSON);
+
+            test1 = new ConfigSetting<string>(Test1Key,
+                                              default,
+                                              SettingScopes.AppSettings |
+                                              SettingScopes.Environment |
+                                              SettingScopes.Json) { AppConfig = appConfig, };
+            test2 = new ConfigSetting<string>(Test2Key, default) { AppConfig = appConfig, };
+
+            test1.Get().Should().Be(JSON);
+            test2.Get().Should().Be(JSON);
+
+            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.AppSettings | SettingScopes.Environment)
+            {
+                AppConfig = appConfig,
+            };
+            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.AppSettings | SettingScopes.Environment)
+            {
+                AppConfig = appConfig,
+            };
+
+            test1.Get().Should().Be(APP);
+            test2.Get().Should().Be(APP);
+
+            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
+            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
+
+            test1.Get().Should().Be(ENV);
+            test2.Get().Should().Be(ENV);
+        }
+
+        [TestMethod]
+        public void Scope_ShouldBe_AppSettings()
+        {
+            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.AppSettings) { AppConfig = appConfig, };
+            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.AppSettings) { AppConfig = appConfig, };
+
+            test1.Get().Should().Be(APP);
+            test2.Get().Should().Be(APP);
+        }
+
+        [TestMethod]
+        public void Scope_ShouldBe_Json()
+        {
+            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.Json) { AppConfig = appConfig, };
+            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.Json) { AppConfig = appConfig, };
+
+            test1.Get().Should().Be(JSON);
+            test2.Get().Should().Be(JSON);
+        }
+
+        [TestMethod]
+        public void Scope_ShouldBe_AppEnvironment()
+        {
+            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
+            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
+
+            test1.Get().Should().Be(ENV);
+            test2.Get().Should().Be(ENV);
+        }
+    }
+}

--- a/AppConfigSettingsTests/Settings.cs
+++ b/AppConfigSettingsTests/Settings.cs
@@ -1,32 +1,45 @@
 ﻿using System;
 using System.IO;
 using AppConfigSettings;
+using AppConfigSettings.Enum;
 
 namespace AppConfigSettingsTests
 {
     public class Settings : SettingsBase<Settings>
     {
         public static readonly ConfigSetting<string> Path =
-            new ConfigSetting<string>("DefaultPath", @"C:\", Directory.Exists, false, Settings2.TestPath);
+            new ConfigSetting<string>("DefaultPath",
+                                      @"C:\",
+                                      SettingScopes.Any,
+                                      Directory.Exists,
+                                      false,
+                                      Settings2.TestPath);
 
         public static readonly ConfigSetting<int> Retries =
-            new ConfigSetting<int>("Retries", 2, i => i > 0, false, Settings2.Retries);
+            new ConfigSetting<int>("Retries", 2, SettingScopes.Any, i => i > 0, false, Settings2.Retries);
 
         public static readonly ConfigSetting<StatusEnum> DefaultStatus =
-            new ConfigSetting<StatusEnum>("DefaultStatus", StatusEnum.Open, status => status != StatusEnum.Closed);
+            new ConfigSetting<StatusEnum>("DefaultStatus",
+                                          StatusEnum.Open,
+                                          SettingScopes.Any,
+                                          status => status != StatusEnum.Closed);
 
-        public static readonly ConfigSetting<string> Author = new ConfigSetting<string>("Author", "Chris");
+        public static readonly ConfigSetting<string> Author =
+            new ConfigSetting<string>("Author", "Chris", SettingScopes.Json | SettingScopes.AppSettings);
 
         public static readonly ConfigSetting<DateTime> Created =
-            new ConfigSetting<DateTime>("Created", DateTime.Today, t => t > DateTime.Parse("1/1/1998"));
+            new ConfigSetting<DateTime>("Created",
+                                        DateTime.Today,
+                                        SettingScopes.Any,
+                                        t => t > DateTime.Parse("1/1/1998"));
 
         public static readonly ConfigSetting<string> HomePath =
-            new ConfigSetting<string>("HomePath", string.Empty, Path);
+            new ConfigSetting<string>("HomePath", string.Empty, SettingScopes.Environment, Path);
 
         public static readonly ConfigSetting<string> LogLevelDefault =
-            new ConfigSetting<string>("Logging:LogLevel:Default", "DefaultDefault");
+            new ConfigSetting<string>("Logging:LogLevel:Default", "DefaultDefault", SettingScopes.Json);
 
         public static readonly ConfigSetting<string> LogLevelLife =
-            new ConfigSetting<string>("Logging:LogLevel:Microsoft.Hosting.Lifetime", "LifeDefault");
+            new ConfigSetting<string>("Logging:LogLevel:Microsoft.Hosting.Lifetime", "LifeDefault", SettingScopes.Json);
     }
 }

--- a/AppConfigSettingsTests/Settings2.cs
+++ b/AppConfigSettingsTests/Settings2.cs
@@ -1,18 +1,20 @@
 ﻿using System.IO;
 using AppConfigSettings;
+using AppConfigSettings.Enum;
 
 namespace AppConfigSettingsTests
 {
     public class Settings2 : SettingsBase<Settings2>
     {
         public static readonly ConfigSetting<string> TestPath =
-            new ConfigSetting<string>("TestPath", @"C:\windows", Directory.Exists);
+            new ConfigSetting<string>("TestPath", @"C:\windows", SettingScopes.Any, Directory.Exists);
 
         public static readonly ConfigSetting<int> Retries =
-            new ConfigSetting<int>("Retries", 55, i => i > 1);
+            new ConfigSetting<int>("Retries", 55, SettingScopes.Any, i => i > 1);
 
         public static readonly ConfigSetting<int> Sections = new ConfigSetting<int>("Sections", 3);
 
-        public static readonly ConfigSetting<string> Public = new ConfigSetting<string>("Public", string.Empty);
+        public static readonly ConfigSetting<string> Public =
+            new ConfigSetting<string>("Public", string.Empty, SettingScopes.Environment);
     }
 }

--- a/TestSettingsConsole/Settings.cs
+++ b/TestSettingsConsole/Settings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using AppConfigSettings;
 using AppConfigSettings.Enum;
@@ -37,7 +36,6 @@ namespace TestSettingsConsole
                                       null,
                                       false,
                                       null,
-                                      new List<string>(),
                                       Environment.CurrentDirectory);
 
         public static readonly ConfigSetting<string> SystemRoot2 =

--- a/TestSettingsConsole/Settings.cs
+++ b/TestSettingsConsole/Settings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using AppConfigSettings;
 using AppConfigSettings.Enum;
@@ -17,12 +18,12 @@ namespace TestSettingsConsole
             new ConfigSetting<int>("MaxRetries", 2, SettingScopes.Any, i => i > 0);
 
         public static readonly ConfigSetting<LoggingLevels> AppLoggingLevel =
-            new ConfigSetting<LoggingLevels>("AppLoggingLevel", LoggingLevels.None);
+            new ConfigSetting<LoggingLevels>("AppLoggingLevel", LoggingLevels.None, SettingScopes.AppSettings);
 
         public static readonly ConfigSetting<LoggingLevels> LogLevel =
             new ConfigSetting<LoggingLevels>("Logging:LogLevel:Default",
                                              LoggingLevels.Information,
-                                             SettingScopes.Any,
+                                             SettingScopes.Json,
                                              AppLoggingLevel);
 
         public static readonly ConfigSetting<string> AllowedHosts = new ConfigSetting<string>("AllowedHosts", "None");
@@ -37,7 +38,7 @@ namespace TestSettingsConsole
                                       false,
                                       null,
                                       new List<string>(),
-                                      false);
+                                      Environment.CurrentDirectory);
 
         public static readonly ConfigSetting<string> SystemRoot2 =
             new ConfigSetting<string>("SystemRoot", "None", SettingScopes.AppSettings | SettingScopes.Environment);

--- a/TestSettingsConsole/Settings.cs
+++ b/TestSettingsConsole/Settings.cs
@@ -1,30 +1,45 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using AppConfigSettings;
+using AppConfigSettings.Enum;
 
 namespace TestSettingsConsole
 {
     public class Settings : SettingsBase<Settings>
     {
         public static readonly ConfigSetting<string> DefaultRunbookFolder =
-            new ConfigSetting<string>("DefaultRunbookFolder", Directory.GetCurrentDirectory(), Directory.Exists);
+            new ConfigSetting<string>("DefaultRunbookFolder",
+                                      Directory.GetCurrentDirectory(),
+                                      SettingScopes.Any,
+                                      Directory.Exists);
 
-        public static readonly ConfigSetting<int> MaxRetries = new ConfigSetting<int>("MaxRetries", 2, i => i > 0);
+        public static readonly ConfigSetting<int> MaxRetries =
+            new ConfigSetting<int>("MaxRetries", 2, SettingScopes.Any, i => i > 0);
 
         public static readonly ConfigSetting<LoggingLevels> AppLoggingLevel =
             new ConfigSetting<LoggingLevels>("AppLoggingLevel", LoggingLevels.None);
 
         public static readonly ConfigSetting<LoggingLevels> LogLevel =
-            new ConfigSetting<LoggingLevels>("Logging:LogLevel:Default", LoggingLevels.Information, AppLoggingLevel);
+            new ConfigSetting<LoggingLevels>("Logging:LogLevel:Default",
+                                             LoggingLevels.Information,
+                                             SettingScopes.Any,
+                                             AppLoggingLevel);
 
         public static readonly ConfigSetting<string> AllowedHosts = new ConfigSetting<string>("AllowedHosts", "None");
 
         public static readonly ConfigSetting<string> TestSetting = new ConfigSetting<string>("TestSetting", "None");
 
         public static readonly ConfigSetting<string> SystemRoot =
-            new ConfigSetting<string>("SystemRoot", "None", null, false, null, new List<string>(), false);
+            new ConfigSetting<string>("SystemRoot",
+                                      "None",
+                                      SettingScopes.AppSettings,
+                                      null,
+                                      false,
+                                      null,
+                                      new List<string>(),
+                                      false);
 
         public static readonly ConfigSetting<string> SystemRoot2 =
-            new ConfigSetting<string>("SystemRoot", "None");
+            new ConfigSetting<string>("SystemRoot", "None", SettingScopes.AppSettings | SettingScopes.Environment);
     }
 }

--- a/src/AppConfigSettings.csproj
+++ b/src/AppConfigSettings.csproj
@@ -34,6 +34,7 @@
 	</Target>
 <ItemGroup>
   <Compile Include="ConfigSetting.cs" />
+  <Compile Include="Enum\SettingScopes.cs" />
   <Compile Include="Interfaces\IConfigSetting.cs" />
   <Compile Include="Interfaces\IConfigSettingT.cs" />
   <Compile Include="SettingsBase.cs" />

--- a/src/ConfigSetting.cs
+++ b/src/ConfigSetting.cs
@@ -39,7 +39,11 @@ namespace AppConfigSettings
         /// <param name="defaultValue">The default value.</param>
         /// <param name="scope">Determines the scope for this setting.</param>
         /// <param name="fallbackSetting">The fallback setting.</param>
-        public ConfigSetting(string key, T defaultValue, SettingScopes scope, ConfigSetting<T> fallbackSetting) :
+        public ConfigSetting(
+            string key,
+            T defaultValue,
+            SettingScopes scope,
+            ConfigSetting<T> fallbackSetting) :
             this(key, defaultValue, scope) => BackupConfigSetting = fallbackSetting;
 
         /// <summary>
@@ -51,7 +55,9 @@ namespace AppConfigSettings
         /// <param name="validation">Validation for the setting.</param>
         /// <param name="throwOnException"></param>
         public ConfigSetting(
-            string key, T defaultValue, SettingScopes scope, Func<T, bool> validation,
+            string key,
+            T defaultValue, SettingScopes scope,
+            Func<T, bool> validation,
             bool throwOnException = false) : this(key,
                                                   defaultValue,
                                                   scope)
@@ -88,37 +94,16 @@ namespace AppConfigSettings
         /// <param name="validation">The validation.</param>
         /// <param name="throwOnException">if set to <c>true</c> [throw on exception].</param>
         /// <param name="fallbackConfigSetting">The fallback configuration setting.</param>
-        /// <param name="jsonFiles">The json files.</param>
-        public ConfigSetting(
-            string key, T defaultValue, SettingScopes scope, Func<T, bool> validation, bool throwOnException,
-            ConfigSetting<T> fallbackConfigSetting, List<string> jsonFiles) : this(key,
-            defaultValue,
-            scope,
-            validation,
-            throwOnException,
-            fallbackConfigSetting) => JsonFiles = jsonFiles;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="scope">Determines the scope for this setting.</param>
-        /// <param name="validation">The validation.</param>
-        /// <param name="throwOnException">if set to <c>true</c> [throw on exception].</param>
-        /// <param name="fallbackConfigSetting">The fallback configuration setting.</param>
-        /// <param name="jsonFiles">The json files.</param>
         /// <param name="defaultDirectory">The default directory.</param>
         public ConfigSetting(
             string key, T defaultValue, SettingScopes scope, Func<T, bool> validation, bool throwOnException,
-            ConfigSetting<T> fallbackConfigSetting, List<string> jsonFiles,
+            ConfigSetting<T> fallbackConfigSetting,
             string defaultDirectory) : this(key,
                                             defaultValue,
                                             scope,
                                             validation,
                                             throwOnException,
-                                            fallbackConfigSetting,
-                                            jsonFiles) => DefaultDirectory = defaultDirectory;
+                                            fallbackConfigSetting) => DefaultDirectory = defaultDirectory;
 
         /// <inheritdoc />
         public List<string> JsonFiles { get; set; }

--- a/src/Enum/SettingScopes.cs
+++ b/src/Enum/SettingScopes.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace AppConfigSettings.Enum
+{
+    [Flags]
+    public enum SettingScopes
+    {
+        Any = 0,
+        AppSettings = 1,
+        Json = 2,
+        Environment = 4,
+    }
+}

--- a/src/Interfaces/IConfigSetting.cs
+++ b/src/Interfaces/IConfigSetting.cs
@@ -25,12 +25,6 @@ namespace AppConfigSettings.Interfaces
         string DefaultDirectory { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether [include environment].
-        /// </summary>
-        /// <value><c>true</c> if [include environment]; otherwise, <c>false</c>.</value>
-        bool IncludeEnvironment { get; set; }
-
-        /// <summary>
         /// Gets or sets the json files.
         /// </summary>
         /// <value>The json files.</value>

--- a/src/Interfaces/IConfigSetting.cs
+++ b/src/Interfaces/IConfigSetting.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Specialized;
+using AppConfigSettings.Enum;
 using Microsoft.Extensions.Configuration;
 
 namespace AppConfigSettings.Interfaces
@@ -40,6 +41,8 @@ namespace AppConfigSettings.Interfaces
         /// </summary>
         /// <value>The key.</value>
         string Key { get; }
+
+        SettingScopes Scopes { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether [throw on exception].


### PR DESCRIPTION
Allow the setting to be assigned a scope for AppSettings, Environment, Json, all of the above, or a combination of options. This tells the system where to look in case there is a conflict where the data comes from. It also simplifies the logic for deciding what sources to include.