### PR TITLE
  - Allow declaring ConfigSetting without a default value - Uses the …

### DIFF
--- a/AppConfigSettingsTests/AppConfigDefaultTests.cs
+++ b/AppConfigSettingsTests/AppConfigDefaultTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Configuration;
+using AppConfigSettings;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -16,13 +17,29 @@ namespace AppConfigSettingsTests
         public void Settings_CleanTest() => Settings.SetAppSettings(ConfigurationManager.AppSettings);
 
         [TestMethod]
-        public void AppConfig_Defaults()
+        public void AppConfig_Defaults_Static()
         {
             Settings.Author.Get().Should().Be("Chris");
             Settings.Created.Get().Should().Be(DateTime.Today);
             Settings.DefaultStatus.Get().Should().Be(StatusEnum.Open);
             Settings.Path.Get().Should().Be(@"C:\");
             Settings.Retries.Get().Should().Be(2);
+        }
+
+        [TestMethod]
+        public void AppConfig_Defaults_Instance()
+        {
+            new ConfigSetting<int>(BAD_VAL).Get().Should().Be(default);
+            new ConfigSetting<int>(BAD_VAL, GOOD_INT).Get().Should().Be(GOOD_INT);
+
+            new ConfigSetting<string>(BAD_VAL).Get().Should().Be(default);
+            new ConfigSetting<string>(BAD_VAL, GOOD_INT.ToString()).Get().Should().Be(GOOD_INT.ToString());
+
+            new ConfigSetting<DateTime>(BAD_VAL).Get().Should().Be(default);
+            new ConfigSetting<DateTime>(BAD_VAL, DateTime.MinValue).Get().Should().Be(DateTime.MinValue);
+
+            new ConfigSetting<StatusEnum>(BAD_VAL).Get().Should().Be(StatusEnum.Open);
+            new ConfigSetting<StatusEnum>(BAD_VAL, StatusEnum.Closed).Get().Should().Be(StatusEnum.Closed);
         }
     }
 }

--- a/AppConfigSettingsTests/AppConfigFallbackTests.cs
+++ b/AppConfigSettingsTests/AppConfigFallbackTests.cs
@@ -12,18 +12,18 @@ namespace AppConfigSettingsTests
         private readonly NameValueCollection appConfig2 = new NameValueCollection
         {
             { Settings2.TestPath.Key, Directory.GetCurrentDirectory() },
-            { Settings2.Retries.Key, "22" },
+            { Settings2.Retries.Key, GOOD_INT.ToString() },
             { Settings2.Sections.Key, "4" },
         };
 
         private readonly NameValueCollection appConfig1Bad = new NameValueCollection
         {
-            { Settings.Path.Key, BadVal }, { Settings.Retries.Key, "0" },
+            { Settings.Path.Key, BAD_VAL }, { Settings.Retries.Key, "0" },
         };
 
         private readonly NameValueCollection appConfig2Bad = new NameValueCollection
         {
-            { Settings2.TestPath.Key, BadVal }, { Settings2.Retries.Key, "-1" },
+            { Settings2.TestPath.Key, BAD_VAL }, { Settings2.Retries.Key, "-1" },
         };
 
         [TestInitialize]
@@ -48,21 +48,21 @@ namespace AppConfigSettingsTests
         {
             Settings2.Sections.Get().Should().Be(4);
             Settings2.TestPath.Get().Should().Be(Directory.GetCurrentDirectory());
-            Settings2.Retries.Get().Should().Be(22);
+            Settings2.Retries.Get().Should().Be(GOOD_INT);
         }
 
         [TestMethod]
         public void GetSettingsBackupImplicit()
         {
             Settings.Path.Get().Should().Be(Directory.GetCurrentDirectory());
-            Settings.Retries.Get().Should().Be(22);
+            Settings.Retries.Get().Should().Be(GOOD_INT);
         }
 
         [TestMethod]
         public void GetSettingsBackupExplicit()
         {
             Settings.Path.Get(Settings2.TestPath).Should().Be(Directory.GetCurrentDirectory());
-            Settings.Retries.Get(Settings2.Retries).Should().Be(22);
+            Settings.Retries.Get(Settings2.Retries).Should().Be(GOOD_INT);
         }
 
         [TestMethod]

--- a/AppConfigSettingsTests/AppConfigSettingsTests.cs
+++ b/AppConfigSettingsTests/AppConfigSettingsTests.cs
@@ -13,7 +13,7 @@ namespace AppConfigSettingsTests
         private readonly NameValueCollection appConfig = new NameValueCollection
         {
             { Settings.Author.Key, "Tom" },
-            { Settings.Created.Key, GoodDate },
+            { Settings.Created.Key, GOOD_DATE },
             { Settings.DefaultStatus.Key, StatusEnum.Unknown.ToString() },
             { Settings.Path.Key, Directory.GetCurrentDirectory() },
             { Settings.Retries.Key, "3" },
@@ -21,9 +21,9 @@ namespace AppConfigSettingsTests
 
         private readonly NameValueCollection appConfigBad = new NameValueCollection
         {
-            { Settings.Created.Key, BadDate },
+            { Settings.Created.Key, BAD_DATE },
             { Settings.DefaultStatus.Key, StatusEnum.Closed.ToString() },
-            { Settings.Path.Key, BadVal },
+            { Settings.Path.Key, BAD_VAL },
             { Settings.Retries.Key, "0" },
         };
 
@@ -37,7 +37,7 @@ namespace AppConfigSettingsTests
         public void Get()
         {
             Settings.Author.Get().Should().Be("Tom");
-            Settings.Created.Get().Should().Be(DateTime.Parse(GoodDate));
+            Settings.Created.Get().Should().Be(DateTime.Parse(GOOD_DATE));
             Settings.DefaultStatus.Get().Should().Be(StatusEnum.Unknown);
             Settings.Path.Get().Should().Be(Directory.GetCurrentDirectory());
             Settings.Retries.Get().Should().Be(3);
@@ -51,7 +51,7 @@ namespace AppConfigSettingsTests
             Settings.Author.TryGet(out var a1).Should().BeTrue();
             a1.Should().Be("Tom");
             Settings.Created.TryGet(out var a2).Should().BeTrue();
-            a2.Should().Be(DateTime.Parse(GoodDate));
+            a2.Should().Be(DateTime.Parse(GOOD_DATE));
             Settings.DefaultStatus.TryGet(out var a3).Should().BeTrue();
             a3.Should().Be(StatusEnum.Unknown);
             Settings.Path.TryGet(out var a4).Should().BeTrue();
@@ -79,15 +79,15 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void Convert_BadConversion()
         {
-            Settings.Created.Convert(BadVal).Should().Be(Settings.Created.DefaultValue);
-            Settings.DefaultStatus.Convert(BadVal).Should().Be(Settings.DefaultStatus.DefaultValue);
-            Settings.Retries.Convert(BadVal).Should().Be(Settings.Retries.DefaultValue);
+            Settings.Created.Convert(BAD_VAL).Should().Be(Settings.Created.DefaultValue);
+            Settings.DefaultStatus.Convert(BAD_VAL).Should().Be(Settings.DefaultStatus.DefaultValue);
+            Settings.Retries.Convert(BAD_VAL).Should().Be(Settings.Retries.DefaultValue);
         }
 
         [TestMethod]
         public void Convert_GoodConversion()
         {
-            Settings.Created.Convert(GoodDate).Should().Be(DateTime.Parse(GoodDate));
+            Settings.Created.Convert(GOOD_DATE).Should().Be(DateTime.Parse(GOOD_DATE));
             Settings.DefaultStatus.Convert(StatusEnum.Unknown.ToString()).Should().Be(StatusEnum.Unknown);
             Settings.Retries.Convert("44").Should().Be(44);
         }
@@ -95,19 +95,19 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void TryConvert_Bad()
         {
-            Settings.Created.TryConvert(BadVal, out var a1).Should().BeFalse();
+            Settings.Created.TryConvert(BAD_VAL, out var a1).Should().BeFalse();
             a1.Should().Be(Settings.Created.DefaultValue);
-            Settings.Retries.TryConvert(BadVal, out var a2).Should().BeFalse();
+            Settings.Retries.TryConvert(BAD_VAL, out var a2).Should().BeFalse();
             a2.Should().Be(Settings.Retries.DefaultValue);
-            Settings.DefaultStatus.TryConvert(BadVal, out var a3).Should().BeFalse();
+            Settings.DefaultStatus.TryConvert(BAD_VAL, out var a3).Should().BeFalse();
             a3.Should().Be(Settings.DefaultStatus.DefaultValue);
         }
 
         [TestMethod]
         public void TryConvert_Good()
         {
-            Settings.Created.TryConvert(GoodDate, out var a1).Should().BeTrue();
-            a1.Should().Be(DateTime.Parse(GoodDate));
+            Settings.Created.TryConvert(GOOD_DATE, out var a1).Should().BeTrue();
+            a1.Should().Be(DateTime.Parse(GOOD_DATE));
             Settings.Retries.TryConvert("1", out var a2).Should().BeTrue();
             a2.Should().Be(1);
             Settings.DefaultStatus.TryConvert("Open", out var a3).Should().BeTrue();

--- a/AppConfigSettingsTests/InstanceTests.cs
+++ b/AppConfigSettingsTests/InstanceTests.cs
@@ -22,16 +22,16 @@ namespace AppConfigSettingsTests
 
         private readonly NameValueCollection appConfig1 = new NameValueCollection
         {
-            { Settings.Path.Key, BadVal },
+            { Settings.Path.Key, BAD_VAL },
             { Settings.Retries.Key, "0" },
             { Settings.Author.Key, "Sam" },
-            { Settings.Created.Key, GoodDate },
+            { Settings.Created.Key, GOOD_DATE },
             { Settings.DefaultStatus.Key, StatusEnum.Unknown.ToString() },
         };
 
         private readonly NameValueCollection appConfig2Bad = new NameValueCollection
         {
-            { Settings2.TestPath.Key, BadVal }, { Settings2.Retries.Key, "-1" },
+            { Settings2.TestPath.Key, BAD_VAL }, { Settings2.Retries.Key, "-1" },
         };
 
         [TestInitialize]
@@ -57,25 +57,25 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void InstanceTests_CompareWithBackup()
         {
-            settings[Settings.Author.Key].Should().Be(Settings.Author.Get());
-            settings[Settings.Created.Key].Should().Be(Settings.Created.Get());
-            settings[Settings.DefaultStatus.Key].Should().Be(Settings.DefaultStatus.Get());
-            settings[Settings.Path.Key].Should().Be(Settings.Path.Get());
-            settings[Settings.Retries.Key].Should().Be(Settings.Retries.Get());
+            settings[nameof(Settings.Author)].Should().Be(Settings.Author.Get());
+            settings[nameof(Settings.Created)].Should().Be(Settings.Created.Get());
+            settings[nameof(Settings.DefaultStatus)].Should().Be(Settings.DefaultStatus.Get());
+            settings[nameof(Settings.Path)].Should().Be(Settings.Path.Get());
+            settings[nameof(Settings.Retries)].Should().Be(Settings.Retries.Get());
         }
 
         [TestMethod]
         public void InstanceTests_CompareWithoutBackup()
         {
-            settings[Settings.Author.Key].Should().Be(Settings.Author.Get(false));
-            settings[Settings.Created.Key].Should().Be(Settings.Created.Get(false));
-            settings[Settings.DefaultStatus.Key].Should().Be(Settings.DefaultStatus.Get(false));
+            settings[nameof(Settings.Author)].Should().Be(Settings.Author.Get(false));
+            settings[nameof(Settings.Created)].Should().Be(Settings.Created.Get(false));
+            settings[nameof(Settings.DefaultStatus)].Should().Be(Settings.DefaultStatus.Get(false));
 
-            settings[Settings.Path.Key].Should().NotBe(Settings.Path.Get(false));
-            settings[Settings.Retries.Key].Should().NotBe(Settings.Retries.Get(false));
+            settings[nameof(Settings.Path)].Should().NotBe(Settings.Path.Get(false));
+            settings[nameof(Settings.Retries)].Should().NotBe(Settings.Retries.Get(false));
 
-            settings[Settings.Path.Key].Should().Be(Settings2.TestPath.Get());
-            settings[Settings.Retries.Key].Should().Be(Settings2.Retries.Get());
+            settings[nameof(Settings.Path)].Should().Be(Settings2.TestPath.Get());
+            settings[nameof(Settings.Retries)].Should().Be(Settings2.Retries.Get());
         }
 
         [TestMethod]

--- a/AppConfigSettingsTests/JsonTests.cs
+++ b/AppConfigSettingsTests/JsonTests.cs
@@ -63,8 +63,8 @@ namespace AppConfigSettingsTests
             Settings.LogLevelLife.Get().Should().Be(expectedLife);
             Settings.LogLevelDefault.Get().Should().Be(expectedDefault);
             var settings = new Settings();
-            settings[Settings.LogLevelDefault.Key].Should().Be(expectedDefault);
-            settings[Settings.LogLevelLife.Key].Should().Be(expectedLife);
+            settings[nameof(Settings.LogLevelDefault)].Should().Be(expectedDefault);
+            settings[nameof(Settings.LogLevelLife)].Should().Be(expectedLife);
         }
 
         [TestMethod]

--- a/AppConfigSettingsTests/TestBase.cs
+++ b/AppConfigSettingsTests/TestBase.cs
@@ -9,9 +9,10 @@ namespace AppConfigSettingsTests
         protected const string APP_SETTINGS_EXT = "json";
         protected const string ASP_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
 
-        protected const string BadVal = "BadVal";
-        protected const string GoodDate = "11/11/1998";
-        protected const string BadDate = "11/11/1997";
+        protected const string BAD_VAL = "BadVal";
+        protected const string GOOD_DATE = "11/11/1998";
+        protected const string BAD_DATE = "11/11/1997";
+        protected const int GOOD_INT = 22;
 
         protected static string CreateFile(string name, string content, string path)
         {

--- a/README.md
+++ b/README.md
@@ -19,11 +19,109 @@ Multiple Source Configuration Reader to manage validated and strongly typed appl
 6. Default Values.
 7. Scope Restrictions - Setting focuses on specific source, if duplicate values are found.
 
-## Available Method Calls
+## Configuration Settings
+
+Configuration settings are independent of each other. The settings may be used in a static class, an instance class, or as standalone declarations in a variable.
+
+### Constructors
+
+When initializing a configuration setting, the only **required** parameter is the **Key**.
+
+#### Basic Constructor with Key, Default Value (optional), and Scope (optional)
+
+```c#
+public ConfigSetting(string key, T defaultValue = default, SettingScopes scope = SettingScopes.Any)
+{
+    Key = key;
+    DefaultValue = defaultValue;
+    Validation = _ => true;
+    ThrowOnException = false;
+    Scopes = scope;
+}
+```
+
+An optional default value will allow the setting to use an expected value when the key is not found or fails validation.
+
+```c#
+[Flags]
+public enum SettingScopes
+{
+    Any = 0,
+    AppSettings = 1,
+    Json = 2,
+    Environment = 4,
+}
+```
+
+The optional scope allows the setting to limit the search scope to any combination of the available configuration scopes:
+
+#### Basic Constructor Plus Fallback Setting
+
+```c#
+public ConfigSetting(
+    string key,
+    T defaultValue,
+    SettingScopes scope,
+    ConfigSetting<T> fallbackSetting) :
+    this(key, defaultValue, scope) => BackupConfigSetting = fallbackSetting;
+```
+
+The fallbackSetting allows the setting to try another configuration setting before failing.
+
+#### Basic Constructor Plus Validation Settings
+
+```c#
+public ConfigSetting(
+    string key,
+    T defaultValue, SettingScopes scope,
+    Func<T, bool> validation,
+    bool throwOnException = false) : this(key,
+                                            defaultValue,
+                                            scope)
+{
+    validation ??= _ => true;
+    Validation = validation;
+    ThrowOnException = throwOnException;
+}
+```
+
+Validation specifies a particular validation function for the value of the setting.
+ThrowOnException specifies whether to throw an error when validation fails. Otherwise, the default value is used.
+
+#### Basic Constructor Plus Validation and Fallback Settings
+
+```c#
+public ConfigSetting(
+    string key, T defaultValue, SettingScopes scope, Func<T, bool> validation, bool throwOnException,
+    ConfigSetting<T> fallbackConfigSetting) : this(key,
+                                                    defaultValue,
+                                                    scope,
+                                                    validation,
+                                                    throwOnException) =>
+    BackupConfigSetting = fallbackConfigSetting;
+```
+
+This combines the validation and fallback constructors into one constructor.
+
+#### Complete Constructor with Default Directory
+
+```c#
+public ConfigSetting(
+    string key, T defaultValue, SettingScopes scope, Func<T, bool> validation, bool throwOnException,
+    ConfigSetting<T> fallbackConfigSetting,
+    string defaultDirectory) : this(key,
+                                    defaultValue,
+                                    scope,
+                                    validation,
+                                    throwOnException,
+                                    fallbackConfigSetting) => DefaultDirectory = defaultDirectory;
+```
+
+Default directory specifies the folder which to search for the configuration settings.
 
 ### Reading Settings
 
-```
+```c#
 public T Get(bool useBackupSetting = true)
 public T Get(ConfigSetting<T> backupConfigSetting)
 public bool TryGet(out T val)
@@ -31,7 +129,7 @@ public bool TryGet(out T val)
 
 ### Setting Conversion
 
-```
+```c#
 public T Convert(string val)
 public bool TryConvert(string val, out T newVal)
 ```
@@ -44,32 +142,121 @@ Get allows retrieval of the setting, respecting the fallback value, but using th
 
 #### Get Settings with backup and defaults
 
-```
-var LogLevel = Settings.LogLevel.Get();
-var Path = Settings.DefaultRunbookFolder.Get();
+Access the static configuration settings from the Settings class.
+
+```c#
+var logLevel = Settings.LogLevel.Get();
+var path = Settings.DefaultFolder.Get();
 var maxRetries = Settings.MaxRetries.Get();
+```
+
+Create a configuration setting and use it immediately.
+
+```c#
+var val = new ConfigSetting<string>("TestSetting").Get();
+```
+
+Create a configuration setting variable and get the value.
+
+```c#
+var testSetting = new ConfigSetting<string>("TestSetting", "My Default");
+testSetting.Get();
+```
+
+Create an instance of the Settings class and access the setting by the name of the variable.
+
+```c#
+var settings = new Settings();
+var level = settings[nameof(Settings.LogLevel)].ToString();
+// Or
+var level2 = settings["LogLevel"].ToString();
 ```
 
 #### Get Settings Without Fallback Setting
 
-```
+To ignore any set fallback settings, pass the boolean, **false**, to the Get method.
+
+```c#
 var LogLevel = Settings.LogLevel.Get(false);
 ```
 
 #### Get Settings With Custom Fallback Setting
 
-```
-var Path = Settings.DefaultRunbookFolder.Get(Settings.SystemRoot);
+To override or use a different configuration setting, pass the configuration setting to the Get method. Either use an existing configuration setting or create a new configuration setting.
+
+```c#
+var Path = Settings.DefaultFolder.Get(Settings.SystemRoot);
 var maxRetries = Settings.MaxRetries.Get(new ConfigSetting<int>("OtherRetry", 2));
+```
+
+## Data Types, Return Values, and Validation
+
+All configuration settings are declared with data types. In the example code below, each setting specifies the data type of the configuration value.
+
+The datatype is validated for proper conversion. The converted data type is passed to the custom validation routine, if supplied.
+
+The return value with Get, TryGet, Convert, and TryConvert will return the data type that is specified.
+
+```c#
+new ConfigSetting<int>("IntKey", 1, SettingScopes.Any, number => number > 0);
+new ConfigSetting<LogLevels>("LogKey", LogLevels.Information, SettingScopes.Any, level => level != LogLevels.None);
+new ConfigSetting<string>("StringKey", string.Empty, SettingScopes.Any, stringSetting => stringSetting != "Foo");
+new ConfigSetting<double?>("NullableDoubleKey", 1.5, SettingScopes.Any, number => number.HasValue && number > 0.5);
+```
+
+## Example Configuration Values
+
+### Basic Setting
+
+The most basic configuration setting will be the key itself.
+
+```c#
+var testSetting = new ConfigSetting<string>("TestSetting");
+```
+
+### Basic Setting with a Default Value and All Configuration Sources
+
+This setting gets the value of **TestSetting** "key" from all available configuration sources. If the key is not found, it returns the string **None**.
+
+```c#
+var testSetting = new ConfigSetting<string>("TestSetting", "None");
+```
+
+### Scope Setting
+
+This setting gets the value of **AllowedHosts** "key" from available _AppSettings_ and _Json_ configuration sources. This setting ignores environment variables. If the key is not found, it returns the string **None**.
+
+```c#
+var allowedHosts = new ConfigSetting<string>("AllowedHosts", "None", SettingScopes.AppSettings | SettingScopes.Json);
+```
+
+### Validation Setting
+
+Both of these settings gets the value from all configuration sources, based on the provided key. Both settings validates the value in different ways. Validation functions are typed as specified in the declaration.
+
+```c#
+new ConfigSetting<int>
+new ConfigSetting<LogLevels>
+new ConfigSetting<string>
+new ConfigSetting<double?>
+```
+
+The first setting validates that the configuration value is _greater (>) than 0._ If the key is _not found_ or the value _fails validation,__ it returns the integer **2**.
+
+The second setting validates that the configuration value exists as a real folder. If the key is _not found_ or the value _fails validation,__ it returns the string **C:\Test**.
+
+```c#
+var maxRetries = new ConfigSetting<int>("MaxRetries", 2, SettingScopes.Any, i => i > 0);
+var folder = new ConfigSetting<string>("Folder", @"C:\Test", SettingScopes.Any, Directory.Exists);
 ```
 
 ## Example Settings
 
-```
+```c#
 public class Settings : SettingsBase<Settings>
 {
-    public static readonly ConfigSetting<string> DefaultRunbookFolder =
-        new ConfigSetting<string>("DefaultRunbookFolder",
+    public static readonly ConfigSetting<string> DefaultFolder =
+        new ConfigSetting<string>("DefaultFolder",
                                     Directory.GetCurrentDirectory(),
                                     SettingScopes.Any,
                                     Directory.Exists);
@@ -107,7 +294,7 @@ public class Settings : SettingsBase<Settings>
 
 | **Setting** | **Data Type** | **Scope** | **Validation** | **Default** | **Fallback Value** |
 | - | - | - | - | - | - |
-| DefaultRunbookFolder | String | Any | Directory existence | Current Directory | None | |
+| DefaultFolder | String | Any | Directory existence | Current Directory | None | |
 | MaxRetries | Integer | Any | MaxRetries > 0 | None | None | |
 | AppLoggingLevel | LoggingLevel (Enum) | AppSettings | None | None | None | |
 | LogLevel | LoggingLevel (Enum) | Json | Default type checking to ensure Enum value is valid. No Custom Validation. | Information | AppLoggingLevel | |
@@ -115,6 +302,21 @@ public class Settings : SettingsBase<Settings>
 | TestSetting | string | Any (Default) | None | None | None | |
 | SystemRoot | String | AppSettings | None | None | None |
 | SystemRoot2 | String | Environment | None | None | None |
+
+## Release Notes
+
+- Current
+  - Allow no default value - Uses the data type default
+  - Instance dictionary uses the name of the variable instead of the configuration settings Key.
+  - Update documentation
+  - Bug Fixes
+
+- 1.21.1.1220
+  - Add Scoping
+  - Bug Fixes
+
+- 1.21.1.1116
+  - Original release
 
 ## MIT License
 

--- a/TestSettingsConsole/App.config
+++ b/TestSettingsConsole/App.config
@@ -2,7 +2,7 @@
 
 <configuration>
 	<appSettings>
-		<add key="DefaultRunbookFolder" value="C:\" />
+		<add key="DefaultFolder" value="C:\" />
 		<add key="AppLoggingLevel" value="Warning" />
 		<add key="MaxRetries" value="11" />
 		<add key="SystemRoot" value="TestRoot" />

--- a/TestSettingsConsole/Program.cs
+++ b/TestSettingsConsole/Program.cs
@@ -10,9 +10,11 @@ namespace TestSettingsConsole
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "");
 
-            var LogLevel = Settings.LogLevel.Get(false);
-            var Path = Settings.DefaultRunbookFolder.Get(Settings.SystemRoot);
+            var logLevel = Settings.LogLevel.Get(false);
+            var path = Settings.DefaultFolder.Get(Settings.SystemRoot);
             var maxRetries = Settings.MaxRetries.Get(new ConfigSetting<int>("OtherRetry", 2));
+            var settings = new Settings();
+            var level = settings[nameof(Settings.LogLevel)].ToString();
 
             Console.WriteLine($"Current Dir: {Directory.GetCurrentDirectory()}");
 
@@ -21,7 +23,7 @@ namespace TestSettingsConsole
 
             Console.WriteLine($"Log Level: {Settings.LogLevel.Get()}");
             Console.WriteLine($"App Log Level: {Settings.AppLoggingLevel.Get()}");
-            Console.WriteLine($"DefaultRunbookFolder: {Settings.DefaultRunbookFolder.Get()}");
+            Console.WriteLine($"DefaultFolder: {Settings.DefaultFolder.Get()}");
             Console.WriteLine($"MaxRetries: {Settings.MaxRetries.Get()}");
             Console.WriteLine($"AllowedHosts: {Settings.AllowedHosts.Get()}");
             Console.WriteLine($"TestSetting: {Settings.TestSetting.Get()}");
@@ -35,7 +37,7 @@ namespace TestSettingsConsole
 
             Console.WriteLine($"Log Level: {Settings.LogLevel.Get()}");
             Console.WriteLine($"App Log Level: {Settings.AppLoggingLevel.Get()}");
-            Console.WriteLine($"DefaultRunbookFolder: {Settings.DefaultRunbookFolder.Get()}");
+            Console.WriteLine($"DefaultFolder: {Settings.DefaultFolder.Get()}");
             Console.WriteLine($"MaxRetries: {Settings.MaxRetries.Get()}");
             Console.WriteLine($"AllowedHosts: {Settings.AllowedHosts.Get()}");
             Console.WriteLine($"TestSetting: {Settings.TestSetting.Get()}");

--- a/TestSettingsConsole/Settings.cs
+++ b/TestSettingsConsole/Settings.cs
@@ -7,8 +7,8 @@ namespace TestSettingsConsole
 {
     public class Settings : SettingsBase<Settings>
     {
-        public static readonly ConfigSetting<string> DefaultRunbookFolder =
-            new ConfigSetting<string>("DefaultRunbookFolder",
+        public static readonly ConfigSetting<string> DefaultFolder =
+            new ConfigSetting<string>("DefaultFolder",
                                       Directory.GetCurrentDirectory(),
                                       SettingScopes.Any,
                                       Directory.Exists);

--- a/src/ConfigSetting.cs
+++ b/src/ConfigSetting.cs
@@ -17,13 +17,39 @@ namespace AppConfigSettings
         private const string APP_SETTINGS_EXT = "json";
         private const string ASP_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
 
+        /// <inheritdoc />
+        public NameValueCollection AppConfig { get; set; } = ConfigurationManager.AppSettings;
+
+        /// <inheritdoc />
+        public ConfigSetting<T> BackupConfigSetting { get; set; }
+
+        /// <inheritdoc />
+        public string DefaultDirectory { get; set; } = Directory.GetCurrentDirectory();
+
+        /// <inheritdoc />
+        public T DefaultValue { get; private set; }
+
+        /// <inheritdoc />
+        public List<string> JsonFiles { get; set; }
+
+        /// <inheritdoc />
+        public string Key { get; private set; }
+
+        public SettingScopes Scopes { get; set; }
+
+        /// <inheritdoc />
+        public bool ThrowOnException { get; set; }
+
+        /// <inheritdoc />
+        public Func<T, bool> Validation { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
         /// </summary>
         /// <param name="key">The key.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="scope">Determines the scope for this setting.</param>
-        public ConfigSetting(string key, T defaultValue, SettingScopes scope = SettingScopes.Any)
+        /// <param name="defaultValue">Optional default value when key is not found or validation fails.</param>
+        /// <param name="scope">Optional <see cref="SettingScopes"/> available to this <see cref="ConfigSetting{T}"/>.</param>
+        public ConfigSetting(string key, T defaultValue = default, SettingScopes scope = SettingScopes.Any)
         {
             Key = key;
             DefaultValue = defaultValue;
@@ -36,9 +62,9 @@ namespace AppConfigSettings
         /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
         /// </summary>
         /// <param name="key">The key.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="scope">Determines the scope for this setting.</param>
-        /// <param name="fallbackSetting">The fallback setting.</param>
+        /// <param name="defaultValue">Default value when key is not found or validation fails.</param>
+        /// <param name="scope"><see cref="SettingScopes"/> available to this <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="fallbackSetting">The fallback <see cref="ConfigSetting{T}"/>.</param>
         public ConfigSetting(
             string key,
             T defaultValue,
@@ -50,10 +76,10 @@ namespace AppConfigSettings
         /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
         /// </summary>
         /// <param name="key">The key.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="scope">Determines the scope for this setting.</param>
-        /// <param name="validation">Validation for the setting.</param>
-        /// <param name="throwOnException"></param>
+        /// <param name="defaultValue">Default value when key is not found or validation fails.</param>
+        /// <param name="scope"><see cref="SettingScopes"/> available to this <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="validation">Validation for the <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="throwOnException">if set to <c>true</c> throw an error when validation fails. Otherwise, the default value is used.</param>
         public ConfigSetting(
             string key,
             T defaultValue, SettingScopes scope,
@@ -71,11 +97,11 @@ namespace AppConfigSettings
         /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
         /// </summary>
         /// <param name="key">The key.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="scope">Determines the scope for this setting.</param>
-        /// <param name="validation">The validation.</param>
-        /// <param name="throwOnException">if set to <c>true</c> [throw on exception].</param>
-        /// <param name="fallbackConfigSetting">The fallback configuration setting.</param>
+        /// <param name="defaultValue">Default value when key is not found or validation fails.</param>
+        /// <param name="scope"><see cref="SettingScopes"/> available to this <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="validation">Validation for the <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="throwOnException">if set to <c>true</c> throw an error when validation fails. Otherwise, the default value is used.</param>
+        /// <param name="fallbackConfigSetting">The fallback <see cref="ConfigSetting{T}"/>.</param>
         public ConfigSetting(
             string key, T defaultValue, SettingScopes scope, Func<T, bool> validation, bool throwOnException,
             ConfigSetting<T> fallbackConfigSetting) : this(key,
@@ -89,12 +115,12 @@ namespace AppConfigSettings
         /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
         /// </summary>
         /// <param name="key">The key.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="scope">Determines the scope for this setting.</param>
-        /// <param name="validation">The validation.</param>
-        /// <param name="throwOnException">if set to <c>true</c> [throw on exception].</param>
-        /// <param name="fallbackConfigSetting">The fallback configuration setting.</param>
-        /// <param name="defaultDirectory">The default directory.</param>
+        /// <param name="defaultValue">Default value when key is not found or validation fails.</param>
+        /// <param name="scope"><see cref="SettingScopes"/> available to this <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="validation">Validation for the <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="throwOnException">if set to <c>true</c> throw an error when validation fails. Otherwise, the default value is used.</param>
+        /// <param name="fallbackConfigSetting">The fallback <see cref="ConfigSetting{T}"/>.</param>
+        /// <param name="defaultDirectory">The default directory containing the configuration settings.</param>
         public ConfigSetting(
             string key, T defaultValue, SettingScopes scope, Func<T, bool> validation, bool throwOnException,
             ConfigSetting<T> fallbackConfigSetting,
@@ -104,24 +130,6 @@ namespace AppConfigSettings
                                             validation,
                                             throwOnException,
                                             fallbackConfigSetting) => DefaultDirectory = defaultDirectory;
-
-        /// <inheritdoc />
-        public List<string> JsonFiles { get; set; }
-
-        /// <inheritdoc />
-        public string DefaultDirectory { get; set; } = Directory.GetCurrentDirectory();
-
-        /// <inheritdoc />
-        public T DefaultValue { get; private set; }
-
-        /// <inheritdoc />
-        public Func<T, bool> Validation { get; set; }
-
-        /// <inheritdoc />
-        public ConfigSetting<T> BackupConfigSetting { get; set; }
-
-        /// <inheritdoc />
-        public NameValueCollection AppConfig { get; set; } = ConfigurationManager.AppSettings;
 
         /// <inheritdoc />
         public IConfigurationRoot Configuration => InitConfig(JsonFiles,
@@ -134,14 +142,6 @@ namespace AppConfigSettings
                                                                JsonFiles.Count == 0),
                                                               false,
                                                               DefaultDirectory);
-
-        /// <inheritdoc />
-        public string Key { get; private set; }
-
-        /// <inheritdoc />
-        public bool ThrowOnException { get; set; }
-
-        public SettingScopes Scopes { get; set; }
 
         /// <inheritdoc />
         public T Get(bool useBackupSetting = true) => Get(useBackupSetting ? BackupConfigSetting : null);

--- a/src/SettingsBase.cs
+++ b/src/SettingsBase.cs
@@ -9,56 +9,58 @@ namespace AppConfigSettings
 {
     public abstract class SettingsBase<T> : Dictionary<string, object> where T : class, new()
     {
-        private const string CONFIG_SETTING_KEY = "Key";
         private const string CONFIG_SETTING_VALUE = "Get";
         private const string CONFIG_SETTING_CONFIG = "AppConfig";
 
-        protected SettingsBase() => ConfigSettings.ForEach(field =>
-                                                           {
-                                                               var fieldType = field?.GetType();
+        protected SettingsBase() => ConfigFields.ForEach(fieldInfo =>
+                                                         {
+                                                             var field = fieldInfo.GetValue(null);
+                                                             var fieldType = field?.GetType();
 
-                                                               if (fieldType == null)
-                                                               {
-                                                                   return;
-                                                               }
+                                                             if (fieldType == null)
+                                                             {
+                                                                 return;
+                                                             }
 
-                                                               var key = fieldType
-                                                                         .GetRuntimeProperty(CONFIG_SETTING_KEY)
-                                                                         ?.GetValue(field)
-                                                                         ?.ToString();
+                                                             var key = ConfigFields
+                                                                       .Where(x => x.FieldHandle ==
+                                                                                  fieldInfo.FieldHandle)
+                                                                       .Select(x => x.Name)
+                                                                       .First();
 
-                                                               if (key == null)
-                                                               {
-                                                                   return;
-                                                               }
+                                                             if (key == null ||
+                                                                 ContainsKey(key))
+                                                             {
+                                                                 return;
+                                                             }
 
-                                                               var getMethod = fieldType
-                                                                   .GetRuntimeMethod(CONFIG_SETTING_VALUE,
-                                                                       new[] { typeof(bool), });
+                                                             var getMethod = fieldType
+                                                                 .GetRuntimeMethod(CONFIG_SETTING_VALUE,
+                                                                     new[] { typeof(bool), });
 
-                                                               object[] paramArray = { true, };
-                                                               var val = getMethod?.Invoke(field, paramArray);
+                                                             object[] paramArray = { true, };
+                                                             var val = getMethod?.Invoke(field, paramArray);
 
-                                                               Add(key, val);
-                                                           });
-
-        private static List<object> ConfigSettings => typeof(T)
-                                                      .GetRuntimeFields()
-                                                      .Where(fieldInfo =>
-                                                                 typeof(IConfigSetting).IsAssignableFrom(
-                                                                     fieldInfo.FieldType) &&
-                                                                 fieldInfo.GetValue(null) != null)
-                                                      .Select(fieldInfo => fieldInfo.GetValue(null))
-                                                      .ToList();
+                                                             Add(key, val);
+                                                         });
 
         /// <summary>
         /// Sets the application settings to override the default.
         /// </summary>
         /// <param name="appSettings">The application settings.</param>
         /// <remarks>Default AppSettings is <see cref="ConfigurationManager.AppSettings"/></remarks>
-        public static void SetAppSettings(NameValueCollection appSettings) => ConfigSettings.ForEach(
-            field => field.GetType()
-                          .GetRuntimeProperty(CONFIG_SETTING_CONFIG)
-                          ?.SetValue(field, appSettings));
+        public static void SetAppSettings(NameValueCollection appSettings) => ConfigFieldValues.ForEach(field => field?
+            .GetType()
+            .GetRuntimeProperty(CONFIG_SETTING_CONFIG)
+            ?.SetValue(field, appSettings));
+
+        private static List<FieldInfo> ConfigFields => typeof(T).GetRuntimeFields()
+                                                                .Where(fieldInfo =>
+                                                                           typeof(IConfigSetting)
+                                                                               .IsAssignableFrom(fieldInfo.FieldType) &&
+                                                                           fieldInfo.GetValue(null) != null)
+                                                                .ToList();
+
+        private static List<object> ConfigFieldValues => ConfigFields.Select(x => x.GetValue(null)).ToList();
     }
 }


### PR DESCRIPTION
- Allow declaring ConfigSetting without a default value - Uses the data type default
- Instance dictionary uses the name of the variable instead of the configuration settings Key.
- Update documentation
- Bug Fixes