### PR TITLE
Injection

### DIFF
--- a/AppConfigSettingsTests/InstanceTests.cs
+++ b/AppConfigSettingsTests/InstanceTests.cs
@@ -29,11 +29,6 @@ namespace AppConfigSettingsTests
             { Settings.DefaultStatus.Key, StatusEnum.Unknown.ToString() },
         };
 
-        private readonly NameValueCollection appConfig2Bad = new NameValueCollection
-        {
-            { Settings2.TestPath.Key, BAD_VAL }, { Settings2.Retries.Key, "-1" },
-        };
-
         [TestInitialize]
         public void Settings_InitTest()
         {

--- a/AppConfigSettingsTests/ProcessSettingTests.cs
+++ b/AppConfigSettingsTests/ProcessSettingTests.cs
@@ -10,11 +10,14 @@ namespace AppConfigSettingsTests
     {
         private const string INIT_AUTHOR = "Chris";
         private const string NEW_AUTHOR = "Tom";
-        private const int NEW_INT = 15;
+        private const string NEW_TEST_KEY = "TESTNUM";
+        private const int NEW_TEST_VAL = 45;
 
         private readonly NameValueCollection appConfig = new NameValueCollection
         {
-            { Settings.Retries.Key, GOOD_INT.ToString() }, { Settings.Author.Key, INIT_AUTHOR },
+            { Settings.Retries.Key, GOOD_INT.ToString() },
+            { Settings.Author.Key, INIT_AUTHOR },
+            { NEW_TEST_KEY, NEW_TEST_VAL.ToString() },
         };
 
         [TestInitialize]
@@ -31,60 +34,30 @@ namespace AppConfigSettingsTests
             author.ProcessSettingValue = selectedSetting =>
                                          {
                                              authorValue = NEW_AUTHOR;
-                                             appConfig[selectedSetting.Key] =
-                                                 NEW_INT.ToString(); // This will update the NEXT call.
 
                                              return true;
                                          };
             authorValue = author.Get();
             authorValue.Should().Be(INIT_AUTHOR);
             authorValue.Should().NotBe(NEW_AUTHOR); // Changed from ProcessSettingValue
-            author.Get().Should().Be(NEW_INT.ToString()); // Changed from ProcessSettingValue
         }
 
         [TestMethod]
         public void ProcessSetting_Int()
         {
             var testInt = 0;
+            var testKey = "";
             var retrySetting = Settings.Retries;
             retrySetting.ProcessSettingValue = selectedSetting =>
                                                {
                                                    testInt = selectedSetting.Value + 3;
-                                                   appConfig[selectedSetting.Key] =
-                                                       NEW_INT.ToString(); // This will update the NEXT call.
+                                                   testKey = selectedSetting.Key;
 
                                                    return true;
                                                };
-            var val = retrySetting.Get(); // ProcessSettingValue ran after getting this value
+            retrySetting.Get(); // ProcessSettingValue ran after getting this value
             testInt.Should().Be(GOOD_INT + 3);
-            val.Should().NotBe(GOOD_INT + 3);
-        }
-
-        [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
-        public void ProcessSetting_TrueFalse(bool isValid)
-        {
-            var retrySetting = Settings.Retries;
-            retrySetting.ProcessSettingValue = selectedSetting =>
-                                               {
-                                                   appConfig[selectedSetting.Key] =
-                                                       NEW_INT.ToString(); // This will update the NEXT call.
-
-                                                   return isValid;
-                                               };
-            var val = retrySetting.Get(); // ProcessSettingValue ran after getting this value
-
-            if (isValid)
-            {
-                val.Should().Be(GOOD_INT);
-                retrySetting.Get().Should().Be(NEW_INT); // New Value
-            }
-            else
-            {
-                val.Should().Be(retrySetting.DefaultValue);
-                retrySetting.Get().Should().Be(retrySetting.DefaultValue); // New Value
-            }
+            testKey.Should().Be(Settings.Retries.Key);
         }
     }
 }

--- a/AppConfigSettingsTests/ProcessSettingTests.cs
+++ b/AppConfigSettingsTests/ProcessSettingTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Specialized;
+using System.Configuration;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AppConfigSettingsTests
+{
+    [TestClass]
+    public class ProcessSettingTests : TestBase
+    {
+        private const string INIT_AUTHOR = "Chris";
+        private const string NEW_AUTHOR = "Tom";
+        private const int NEW_INT = 15;
+
+        private readonly NameValueCollection appConfig = new NameValueCollection
+        {
+            { Settings.Retries.Key, GOOD_INT.ToString() }, { Settings.Author.Key, INIT_AUTHOR },
+        };
+
+        [TestInitialize]
+        public void InitTest() => Settings.SetAppSettings(appConfig);
+
+        [TestCleanup]
+        public void CleanTest() => Settings.SetAppSettings(ConfigurationManager.AppSettings);
+
+        [TestMethod]
+        public void ProcessSetting_Author()
+        {
+            var author = Settings.Author;
+            var authorValue = string.Empty;
+            author.ProcessSettingValue = selectedSetting =>
+                                         {
+                                             authorValue = NEW_AUTHOR;
+                                             appConfig[selectedSetting.Key] =
+                                                 NEW_INT.ToString(); // This will update the NEXT call.
+
+                                             return true;
+                                         };
+            authorValue = author.Get();
+            authorValue.Should().Be(INIT_AUTHOR);
+            authorValue.Should().NotBe(NEW_AUTHOR); // Changed from ProcessSettingValue
+            author.Get().Should().Be(NEW_INT.ToString()); // Changed from ProcessSettingValue
+        }
+
+        [TestMethod]
+        public void ProcessSetting_Int()
+        {
+            var testInt = 0;
+            var retrySetting = Settings.Retries;
+            retrySetting.ProcessSettingValue = selectedSetting =>
+                                               {
+                                                   testInt = selectedSetting.Value + 3;
+                                                   appConfig[selectedSetting.Key] =
+                                                       NEW_INT.ToString(); // This will update the NEXT call.
+
+                                                   return true;
+                                               };
+            var val = retrySetting.Get(); // ProcessSettingValue ran after getting this value
+            testInt.Should().Be(GOOD_INT + 3);
+            val.Should().NotBe(GOOD_INT + 3);
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void ProcessSetting_TrueFalse(bool isValid)
+        {
+            var retrySetting = Settings.Retries;
+            retrySetting.ProcessSettingValue = selectedSetting =>
+                                               {
+                                                   appConfig[selectedSetting.Key] =
+                                                       NEW_INT.ToString(); // This will update the NEXT call.
+
+                                                   return isValid;
+                                               };
+            var val = retrySetting.Get(); // ProcessSettingValue ran after getting this value
+
+            if (isValid)
+            {
+                val.Should().Be(GOOD_INT);
+                retrySetting.Get().Should().Be(NEW_INT); // New Value
+            }
+            else
+            {
+                val.Should().Be(retrySetting.DefaultValue);
+                retrySetting.Get().Should().Be(retrySetting.DefaultValue); // New Value
+            }
+        }
+    }
+}

--- a/AppConfigSettingsTests/ScopeTests.cs
+++ b/AppConfigSettingsTests/ScopeTests.cs
@@ -17,18 +17,18 @@ namespace AppConfigSettingsTests
         private const string APP = "FromApp";
         private const string ENV = "FromEnv";
 
-        private const string Test1Key = "Test1";
-        private const string Test2Key = "Test2";
+        private const string TEST1_KEY = "Test1";
+        private const string TEST2_KEY = "Test2";
 
         private const string JSON_CONFIG =
             "{\r\n  \"Test1\": \"FromJson\",\r\n  \"Test2\": \"FromJson\"\r\n}";
 
-        private static ConfigSetting<string> test1 = new ConfigSetting<string>("Test1", default);
-        private static ConfigSetting<string> test2 = new ConfigSetting<string>("Test2", default);
+        private static ConfigSetting<string> test1 = new ConfigSetting<string>("Test1");
+        private static ConfigSetting<string> test2 = new ConfigSetting<string>("Test2");
 
         private readonly NameValueCollection appConfig = new NameValueCollection
         {
-            { Test1Key, APP }, { Test2Key, APP },
+            { TEST1_KEY, APP }, { TEST2_KEY, APP },
         };
 
         private readonly List<string> filePaths = new List<string>();
@@ -36,8 +36,8 @@ namespace AppConfigSettingsTests
         [TestInitialize]
         public void Settings_InitTest()
         {
-            Environment.SetEnvironmentVariable(Test1Key, ENV);
-            Environment.SetEnvironmentVariable(Test2Key, ENV);
+            Environment.SetEnvironmentVariable(TEST1_KEY, ENV);
+            Environment.SetEnvironmentVariable(TEST2_KEY, ENV);
 
             filePaths.Add(CreateFile($"{APP_SETTINGS_NAME}.{APP_SETTINGS_EXT}",
                                      JSON_CONFIG,
@@ -47,8 +47,8 @@ namespace AppConfigSettingsTests
         [TestCleanup]
         public void Settings_CleanTest()
         {
-            Environment.SetEnvironmentVariable(Test1Key, null);
-            Environment.SetEnvironmentVariable(Test2Key, null);
+            Environment.SetEnvironmentVariable(TEST1_KEY, null);
+            Environment.SetEnvironmentVariable(TEST2_KEY, null);
 
             Settings.SetAppSettings(ConfigurationManager.AppSettings);
             filePaths.ForEach(DeleteFile);
@@ -57,36 +57,45 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void Scope_ShouldBe_JSON_APP_ENV()
         {
-            test1 = new ConfigSetting<string>(Test1Key, default) { AppConfig = appConfig, };
-            test2 = new ConfigSetting<string>(Test2Key, default) { AppConfig = appConfig, };
+            test1 = new ConfigSetting<string>(TEST1_KEY);
+            test1.SetAppSettings(appConfig);
+            test2 = new ConfigSetting<string>(TEST2_KEY);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(JSON);
             test2.Get().Should().Be(JSON);
 
-            test1 = new ConfigSetting<string>(Test1Key,
+            test1 = new ConfigSetting<string>(TEST1_KEY,
                                               default,
                                               SettingScopes.AppSettings |
                                               SettingScopes.Environment |
-                                              SettingScopes.Json) { AppConfig = appConfig, };
-            test2 = new ConfigSetting<string>(Test2Key, default) { AppConfig = appConfig, };
+                                              SettingScopes.Json);
+            test1.SetAppSettings(appConfig);
+
+            test2 = new ConfigSetting<string>(TEST2_KEY);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(JSON);
             test2.Get().Should().Be(JSON);
 
-            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.AppSettings | SettingScopes.Environment)
-            {
-                AppConfig = appConfig,
-            };
-            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.AppSettings | SettingScopes.Environment)
-            {
-                AppConfig = appConfig,
-            };
+            test1 = new ConfigSetting<string>(TEST1_KEY,
+                                              default,
+                                              SettingScopes.AppSettings | SettingScopes.Environment);
+            test1.SetAppSettings(appConfig);
+
+            test2 = new ConfigSetting<string>(TEST2_KEY,
+                                              default,
+                                              SettingScopes.AppSettings | SettingScopes.Environment);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(APP);
             test2.Get().Should().Be(APP);
 
-            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
-            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
+            test1 = new ConfigSetting<string>(TEST1_KEY, default, SettingScopes.Environment);
+            test1.SetAppSettings(appConfig);
+
+            test2 = new ConfigSetting<string>(TEST2_KEY, default, SettingScopes.Environment);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(ENV);
             test2.Get().Should().Be(ENV);
@@ -95,8 +104,11 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void Scope_ShouldBe_AppSettings()
         {
-            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.AppSettings) { AppConfig = appConfig, };
-            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.AppSettings) { AppConfig = appConfig, };
+            test1 = new ConfigSetting<string>(TEST1_KEY, default, SettingScopes.AppSettings);
+            test1.SetAppSettings(appConfig);
+
+            test2 = new ConfigSetting<string>(TEST2_KEY, default, SettingScopes.AppSettings);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(APP);
             test2.Get().Should().Be(APP);
@@ -105,8 +117,11 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void Scope_ShouldBe_Json()
         {
-            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.Json) { AppConfig = appConfig, };
-            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.Json) { AppConfig = appConfig, };
+            test1 = new ConfigSetting<string>(TEST1_KEY, default, SettingScopes.Json);
+            test1.SetAppSettings(appConfig);
+
+            test2 = new ConfigSetting<string>(TEST2_KEY, default, SettingScopes.Json);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(JSON);
             test2.Get().Should().Be(JSON);
@@ -115,8 +130,11 @@ namespace AppConfigSettingsTests
         [TestMethod]
         public void Scope_ShouldBe_AppEnvironment()
         {
-            test1 = new ConfigSetting<string>(Test1Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
-            test2 = new ConfigSetting<string>(Test2Key, default, SettingScopes.Environment) { AppConfig = appConfig, };
+            test1 = new ConfigSetting<string>(TEST1_KEY, default, SettingScopes.Environment);
+            test1.SetAppSettings(appConfig);
+
+            test2 = new ConfigSetting<string>(TEST2_KEY, default, SettingScopes.Environment);
+            test2.SetAppSettings(appConfig);
 
             test1.Get().Should().Be(ENV);
             test2.Get().Should().Be(ENV);

--- a/AppConfigSettingsTests/ValidationTests.cs
+++ b/AppConfigSettingsTests/ValidationTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.IO;
+using AppConfigSettings;
+using AppConfigSettings.Enum;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AppConfigSettingsTests
+{
+    [TestClass]
+    public class ValidationTests : TestBase
+    {
+        private const string KEY = "TEST";
+
+        private readonly NameValueCollection appConfig = new NameValueCollection { { KEY, GOOD_INT.ToString() }, };
+
+        private readonly ConfigSetting<int> setting =
+            new ConfigSetting<int>(KEY, 21, SettingScopes.Any, i => i > GOOD_INT);
+
+        private readonly ConfigSetting<int> setting2 =
+            new ConfigSetting<int>(KEY, 19, SettingScopes.Any, i => i > GOOD_INT);
+
+        private readonly ConfigSetting<int> setting3 =
+            new ConfigSetting<int>(BAD_VAL, 19, SettingScopes.Any, i => i > GOOD_INT);
+
+        [TestInitialize]
+        public void InitTests()
+        {
+            setting.SetAppSettings(appConfig);
+            setting2.SetAppSettings(appConfig);
+            setting3.SetAppSettings(appConfig);
+        }
+
+        [TestMethod]
+        public void TestException_False()
+        {
+            Func<int> a1 = () => setting.Get();
+            a1.Should().NotThrow();
+
+            Func<int> a2 = () => setting2.Get();
+            a2.Should().NotThrow();
+
+            Func<int> a4 = () => setting3.Get();
+            a4.Should().NotThrow();
+        }
+
+        [TestMethod]
+        public void TestException_True()
+        {
+            setting2.ThrowOnException = true;
+            Func<int> a2 = () => setting2.Get();
+            a2.Should().Throw<InvalidDataException>();
+
+            setting3.ThrowOnException = true;
+            Func<int> a4 = () => setting3.Get();
+            a4.Should().Throw<InvalidCastException>();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -306,7 +306,28 @@ public class Settings : SettingsBase<Settings>
 ## Release Notes
 
 - Current
-  - Allow no default value - Uses the data type default
+  - Remove AppConfig setting from ConfigSetting public interface.
+  - Add SetAppSettings(NameValueCollection appSettings) to ConfigSetting public interface.
+  - Add Action ProcessSettingValue to process data based on found value.
+    - Example:
+  
+```c#
+            setting.ProcessSettingValue = selectedSetting =>
+                                            {
+                                                testInt = selectedSetting.Value + 3;
+                                                appConfig[selectedSetting.Key] =
+                                                    NEW_INT.ToString(); // This will update the NEXT call.
+
+                                                return true;
+                                            };
+
+```
+
+- 1.21.1.1619
+  - Convert project to .NET Standard 2.0 for greater compatibility.
+
+- 1.21.1.1602
+  - Allow declaring ConfigSetting without a default value - Uses the data type default.
   - Instance dictionary uses the name of the variable instead of the configuration settings Key.
   - Update documentation
   - Bug Fixes

--- a/README.md
+++ b/README.md
@@ -315,10 +315,9 @@ public class Settings : SettingsBase<Settings>
             setting.ProcessSettingValue = selectedSetting =>
                                             {
                                                 testInt = selectedSetting.Value + 3;
-                                                appConfig[selectedSetting.Key] =
-                                                    NEW_INT.ToString(); // This will update the NEXT call.
+                                                testKey = selectedSetting.Key;
 
-                                                return true;
+                                                return selectedSetting.Key == "foo";
                                             };
 
 ```

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ public class Settings : SettingsBase<Settings>
 - Current
   - Remove AppConfig setting from ConfigSetting public interface.
   - Add SetAppSettings(NameValueCollection appSettings) to ConfigSetting public interface.
+  - Add Missing ThrowOnException code.
   - Add Action ProcessSettingValue to process data based on found value.
     - Example:
   

--- a/TestSettingsConsole/Program.cs
+++ b/TestSettingsConsole/Program.cs
@@ -36,7 +36,7 @@ namespace TestSettingsConsole
             Console.WriteLine($"MaxRetries: {Settings.MaxRetries.Get()}");
 
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-
+            Settings.MaxRetries.AddDefaultJson();
             Console.WriteLine("");
             Console.WriteLine("Development:");
 

--- a/TestSettingsConsole/Program.cs
+++ b/TestSettingsConsole/Program.cs
@@ -16,6 +16,11 @@ namespace TestSettingsConsole
             var settings = new Settings();
             var level = settings[nameof(Settings.LogLevel)].ToString();
 
+            Console.WriteLine(logLevel);
+            Console.WriteLine(level);
+            Console.WriteLine(path);
+            Console.WriteLine(maxRetries);
+
             Console.WriteLine($"Current Dir: {Directory.GetCurrentDirectory()}");
 
             Console.WriteLine("");
@@ -24,25 +29,20 @@ namespace TestSettingsConsole
             Console.WriteLine($"Log Level: {Settings.LogLevel.Get()}");
             Console.WriteLine($"App Log Level: {Settings.AppLoggingLevel.Get()}");
             Console.WriteLine($"DefaultFolder: {Settings.DefaultFolder.Get()}");
-            Console.WriteLine($"MaxRetries: {Settings.MaxRetries.Get()}");
             Console.WriteLine($"AllowedHosts: {Settings.AllowedHosts.Get()}");
             Console.WriteLine($"TestSetting: {Settings.TestSetting.Get()}");
             Console.WriteLine($"SystemRoot: {Settings.SystemRoot.Get()}");
             Console.WriteLine($"SystemRoot2: {Settings.SystemRoot2.Get()}");
+
+            Console.WriteLine($"MaxRetries: {Settings.MaxRetries.Get()}");
 
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
 
             Console.WriteLine("");
             Console.WriteLine("Development:");
 
-            Console.WriteLine($"Log Level: {Settings.LogLevel.Get()}");
-            Console.WriteLine($"App Log Level: {Settings.AppLoggingLevel.Get()}");
-            Console.WriteLine($"DefaultFolder: {Settings.DefaultFolder.Get()}");
             Console.WriteLine($"MaxRetries: {Settings.MaxRetries.Get()}");
-            Console.WriteLine($"AllowedHosts: {Settings.AllowedHosts.Get()}");
-            Console.WriteLine($"TestSetting: {Settings.TestSetting.Get()}");
-            Console.WriteLine($"SystemRoot: {Settings.SystemRoot.Get()}");
-            Console.WriteLine($"SystemRoot2: {Settings.SystemRoot2.Get()}");
+
             Console.ReadKey();
         }
     }

--- a/TestSettingsConsole/Program.cs
+++ b/TestSettingsConsole/Program.cs
@@ -6,18 +6,17 @@ namespace TestSettingsConsole
 {
     internal class Program
     {
-        private static void Main(string[] args)
+        private static void Main()
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "");
 
             var logLevel = Settings.LogLevel.Get(false);
             var path = Settings.DefaultFolder.Get(Settings.SystemRoot);
             var maxRetries = Settings.MaxRetries.Get(new ConfigSetting<int>("OtherRetry", 2));
-            var settings = new Settings();
-            var level = settings[nameof(Settings.LogLevel)].ToString();
+            var level = new Settings()[nameof(Settings.LogLevel)].ToString();
 
-            Console.WriteLine(logLevel);
-            Console.WriteLine(level);
+            Console.WriteLine($"Static: {logLevel}");
+            Console.WriteLine($"Instance: {level}");
             Console.WriteLine(path);
             Console.WriteLine(maxRetries);
 

--- a/src/AppConfigSettings.csproj
+++ b/src/AppConfigSettings.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright(c) 2021 Christopher Winland</Copyright>
-    <RepositoryUrl>https://github.com/cwinland/AppConfigSettings</RepositoryUrl>
-    <RepositoryType>GitHub</RepositoryType>
-    <PackageTags>Application Configuration Settings Validation Typed AppConfig</PackageTags>
-    <Company>Microsoft</Company>
-    <Authors>Christopher Winland</Authors>
-    <Description>Typed and validated application configuration settings. Allows backup configuration such as parent / child settings. Based off ConfigurationManager, JSON, and Environment Variables.</Description>
-	<Title>App Settings Multi-Configuration</Title>
-	<PackageTags>AppConfig Validation Configuration Settings Backup Fallback ConfigurationManager Typed AppSettings JSON Environment Variables</PackageTags>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<Copyright>Copyright(c) 2021 Christopher Winland</Copyright>
+		<RepositoryUrl>https://github.com/cwinland/AppConfigSettings</RepositoryUrl>
+		<RepositoryType>GitHub</RepositoryType>
+		<PackageTags>Application Configuration Settings Validation Typed AppConfig</PackageTags>
+		<Company>Microsoft</Company>
+		<Authors>Christopher Winland</Authors>
+		<Description>Typed and validated application configuration settings. Allows backup configuration such as parent / child settings. Based off ConfigurationManager, JSON, and Environment Variables.</Description>
+		<Title>App Settings Multi-Configuration</Title>
+		<PackageTags>AppConfig Validation Configuration Settings Backup Fallback ConfigurationManager Typed AppSettings JSON Environment Variables</PackageTags>
+	</PropertyGroup>
 	<PropertyGroup>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<AssemblyVersion>1.$([System.DateTime]::Now.ToString("y.MM.ddHH"))</AssemblyVersion>
@@ -26,34 +26,35 @@
 		<PackageProjectUrl></PackageProjectUrl>
 		<Product>Multiple Configuration Settings</Product>
 	</PropertyGroup>
-<Target Name="SetPackageVersion">
+	<Target Name="SetPackageVersion">
 		<PropertyGroup>
 			<!-- <PackageVersion>$([System.DateTime]::Now.ToString(&quot;yyyy.MM.dd.HHmmss&quot;))</PackageVersion> -->
 			<!-- You can customize the format and the rule about how version increases here. -->
 			<PackageVersion>1.$([System.DateTime]::Now.ToString("y.MM.ddHH"))</PackageVersion>
 		</PropertyGroup>
 	</Target>
-<ItemGroup>
-  <Compile Include="ConfigSetting.cs" />
-  <Compile Include="Enum\SettingScopes.cs" />
-  <Compile Include="Interfaces\IConfigSetting.cs" />
-  <Compile Include="Interfaces\IConfigSettingT.cs" />
-  <Compile Include="SettingsBase.cs" />
-</ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="ConfigSetting.cs" />
+		<Compile Include="Enum\SettingScopes.cs" />
+		<Compile Include="Interfaces\IConfigSetting.cs" />
+		<Compile Include="Interfaces\IConfigSettingT.cs" />
+		<Compile Include="SelectedSetting.cs" />
+		<Compile Include="SettingsBase.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/src/AppConfigSettings.csproj
+++ b/src/AppConfigSettings.csproj
@@ -34,6 +34,7 @@
 		</PropertyGroup>
 	</Target>
 	<ItemGroup>
+		<Compile Include="ConfigFieldInfo.cs" />
 		<Compile Include="ConfigSetting.cs" />
 		<Compile Include="Enum\SettingScopes.cs" />
 		<Compile Include="Interfaces\IConfigSetting.cs" />

--- a/src/ConfigFieldInfo.cs
+++ b/src/ConfigFieldInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using AppConfigSettings.Interfaces;
+
+namespace AppConfigSettings
+{
+    public class ConfigFieldInfo
+    {
+        public FieldInfo Info { get; }
+        public IConfigSetting Value { get; }
+
+        public ConfigFieldInfo(FieldInfo info)
+        {
+            Info = info;
+            Value = info.GetValue(null) as IConfigSetting;
+        }
+    }
+}

--- a/src/ConfigSetting.cs
+++ b/src/ConfigSetting.cs
@@ -138,18 +138,16 @@ namespace AppConfigSettings
                                             fallbackConfigSetting) => DefaultDirectory = defaultDirectory;
 
         /// <inheritdoc />
-        public IConfigurationRoot Configuration => InitConfig(
-            HasScope(SettingScopes.Json) ? JsonFiles ?? AddDefaultJson() : new List<string>(),
-            HasScope(SettingScopes.AppSettings)
-                ? AppConfig ??
-                  GetKeyPairSettings(ConfigurationManager.AppSettings)
-                : new List<KeyValuePair<string, string>>(),
-            HasScope(SettingScopes.Environment),
-            HasScope(SettingScopes.Json) &&
-            (JsonFiles == null ||
-             JsonFiles.Count == 0),
-            false,
-            DefaultDirectory);
+        public IConfigurationRoot Configuration => BuildConfig(DefaultDirectory,
+                                                               HasScope(SettingScopes.AppSettings)
+                                                                   ? AppConfig ??
+                                                                     GetKeyPairSettings(
+                                                                         ConfigurationManager.AppSettings)
+                                                                   : new List<KeyValuePair<string, string>>(),
+                                                               HasScope(SettingScopes.Json)
+                                                                   ? JsonFiles ?? AddDefaultJson()
+                                                                   : new List<string>(),
+                                                               HasScope(SettingScopes.Environment));
 
         /// <inheritdoc />
         public T Get(bool useBackupSetting = true) => Get(useBackupSetting ? BackupConfigSetting : null);
@@ -222,29 +220,6 @@ namespace AppConfigSettings
             ProcessSettingValue?.Invoke(new SelectedSetting<T>(setting, validSetting)) ?? true
                 ? setting
                 : defaultValue;
-
-        private static IConfigurationRoot InitConfig(
-            List<string> jsonFiles, List<KeyValuePair<string, string>> appSettingsCollections,
-            bool includeEnvironmentVariables, bool addDefaultJson, bool addDefaultAppSettings, string currentDirectory)
-        {
-            if (jsonFiles == null)
-            {
-                jsonFiles = new List<string>();
-            }
-
-            if (appSettingsCollections == null)
-            {
-                appSettingsCollections = new List<KeyValuePair<string, string>>();
-            }
-
-            if (addDefaultAppSettings)
-            {
-                GetKeyPairSettings(ConfigurationManager.AppSettings)
-                    .ForEach(x => appSettingsCollections.Add(new KeyValuePair<string, string>(x.Key, x.Value)));
-            }
-
-            return BuildConfig(currentDirectory, appSettingsCollections, jsonFiles, includeEnvironmentVariables);
-        }
 
         private List<string> AddDefaultJson()
         {

--- a/src/ConfigSetting.cs
+++ b/src/ConfigSetting.cs
@@ -43,8 +43,7 @@ namespace AppConfigSettings
         /// <inheritdoc />
         public Func<T, bool> Validation { get; set; }
 
-        private List<KeyValuePair<string, string>> AppConfig { get; set; } =
-            GetKeyPairSettings(ConfigurationManager.AppSettings);
+        private List<KeyValuePair<string, string>> AppConfig { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigSetting{T}"/> class.
@@ -141,7 +140,8 @@ namespace AppConfigSettings
         /// <inheritdoc />
         public IConfigurationRoot Configuration => InitConfig(JsonFiles,
                                                               HasScope(SettingScopes.AppSettings)
-                                                                  ? AppConfig
+                                                                  ? AppConfig ??
+                                                                    GetKeyPairSettings(ConfigurationManager.AppSettings)
                                                                   : new List<KeyValuePair<string, string>>(),
                                                               HasScope(SettingScopes.Environment),
                                                               HasScope(SettingScopes.Json) &&

--- a/src/ConfigSetting.cs
+++ b/src/ConfigSetting.cs
@@ -216,12 +216,8 @@ namespace AppConfigSettings
         public void SetAppSettings(NameValueCollection appSettings) => AppConfig =
             new List<KeyValuePair<string, string>>(1) { new KeyValuePair<string, string>(Key, appSettings[Key]), };
 
-        private T SettingFound(T setting, IConfigSetting validSetting, T defaultValue) =>
-            ProcessSettingValue?.Invoke(new SelectedSetting<T>(setting, validSetting)) ?? true
-                ? setting
-                : defaultValue;
-
-        private List<string> AddDefaultJson()
+        /// <inheritdoc />
+        public List<string> AddDefaultJson()
         {
             var env = Environment.GetEnvironmentVariable(ASP_ENVIRONMENT);
 
@@ -230,15 +226,30 @@ namespace AppConfigSettings
                 JsonFiles = new List<string>();
             }
 
-            JsonFiles.Add($"{APP_SETTINGS_NAME}.{APP_SETTINGS_EXT}");
+            var name = $"{APP_SETTINGS_NAME}.{APP_SETTINGS_EXT}";
+
+            if (!JsonFiles.Contains(name))
+            {
+                JsonFiles.Add(name);
+            }
 
             if (!string.IsNullOrWhiteSpace(env))
             {
-                JsonFiles.Add($"{APP_SETTINGS_NAME}.{env}.{APP_SETTINGS_EXT}");
+                name = $"{APP_SETTINGS_NAME}.{env}.{APP_SETTINGS_EXT}";
+
+                if (!JsonFiles.Contains(name))
+                {
+                    JsonFiles.Add(name);
+                }
             }
 
             return JsonFiles;
         }
+
+        private T SettingFound(T setting, IConfigSetting validSetting, T defaultValue) =>
+            ProcessSettingValue?.Invoke(new SelectedSetting<T>(setting, validSetting)) ?? true
+                ? setting
+                : defaultValue;
 
         /// <summary>
         /// Builds the configuration.

--- a/src/Interfaces/IConfigSetting.cs
+++ b/src/Interfaces/IConfigSetting.cs
@@ -45,5 +45,12 @@ namespace AppConfigSettings.Interfaces
         /// </summary>
         /// <value><c>true</c> if [throw on exception]; otherwise, <c>false</c>.</value>
         bool ThrowOnException { get; set; }
+
+        /// <summary>
+        /// Adds the default json.
+        /// </summary>
+        /// <returns>List&lt;System.String&gt;.</returns>
+        /// <remarks>Must be called again to update if the environment variable 'ASPNETCORE_ENVIRONMENT' changes.</remarks>
+        List<string> AddDefaultJson();
     }
 }

--- a/src/Interfaces/IConfigSetting.cs
+++ b/src/Interfaces/IConfigSetting.cs
@@ -10,7 +10,9 @@ namespace AppConfigSettings.Interfaces
         /// <summary>
         /// Configuration App Settings
         /// </summary>
-        NameValueCollection AppConfig { get; set; }
+
+        //NameValueCollection AppConfig { get; set; }
+        void SetAppSettings(NameValueCollection appSettings);
 
         /// <summary>
         /// Overall Configurations

--- a/src/Interfaces/IConfigSettingT.cs
+++ b/src/Interfaces/IConfigSettingT.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace AppConfigSettings.Interfaces
 {
@@ -38,6 +39,8 @@ namespace AppConfigSettings.Interfaces
         /// </summary>
         /// <param name="val">The value.</param>
         /// <returns><c>true</c> if valid value and validation, <c>false</c> otherwise.</returns>
+        /// <exception cref="InvalidDataException"></exception>
+        /// <exception cref="InvalidCastException"></exception>
         bool TryGet(out T val);
 
         /// <summary>

--- a/src/Interfaces/IConfigSettingT.cs
+++ b/src/Interfaces/IConfigSettingT.cs
@@ -30,14 +30,14 @@ namespace AppConfigSettings.Interfaces
         /// </summary>
         /// <param name="val">The value.</param>
         /// <param name="newVal">The new value.</param>
-        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if possible to convert, <c>false</c> otherwise.</returns>
         bool TryConvert(string val, out T newVal);
 
         /// <summary>
         /// Tries the get.
         /// </summary>
         /// <param name="val">The value.</param>
-        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if valid value and validation, <c>false</c> otherwise.</returns>
         bool TryGet(out T val);
 
         /// <summary>
@@ -51,6 +51,15 @@ namespace AppConfigSettings.Interfaces
         /// </summary>
         /// <value>The default value.</value>
         T DefaultValue { get; }
+
+        /// <summary>
+        /// Gets or sets the process setting value callback function. This function is designed to allow the caller to act on the found setting.
+        /// </summary>
+        /// <example>
+        /// 
+        /// </example>
+        /// <value>The process setting value.</value>
+        Func<SelectedSetting<T>, bool> ProcessSettingValue { get; set; }
 
         /// <summary>
         /// Gets or sets the validation.

--- a/src/SelectedSetting.cs
+++ b/src/SelectedSetting.cs
@@ -1,0 +1,16 @@
+﻿using AppConfigSettings.Interfaces;
+
+namespace AppConfigSettings
+{
+    public class SelectedSetting<T>
+    {
+        public string Key { get; }
+        public T Value { get; }
+
+        internal SelectedSetting(T value, IConfigSetting configSetting)
+        {
+            Value = value;
+            Key = configSetting.Key;
+        }
+    }
+}

--- a/src/SelectedSetting.cs
+++ b/src/SelectedSetting.cs
@@ -5,6 +5,7 @@ namespace AppConfigSettings
     public class SelectedSetting<T>
     {
         public string Key { get; }
+
         public T Value { get; }
 
         internal SelectedSetting(T value, IConfigSetting configSetting)

--- a/src/SettingsBase.cs
+++ b/src/SettingsBase.cs
@@ -13,7 +13,7 @@ namespace AppConfigSettings
 
         protected SettingsBase() => ConfigFields.ForEach(fieldInfo =>
                                                          {
-                                                             var field = fieldInfo.GetValue(null);
+                                                             var field = fieldInfo.GetValue(null) as IConfigSetting;
                                                              var fieldType = field?.GetType();
 
                                                              if (fieldType == null)
@@ -48,11 +48,13 @@ namespace AppConfigSettings
         /// </summary>
         /// <param name="appSettings">The application settings.</param>
         /// <remarks>Default AppSettings is <see cref="ConfigurationManager.AppSettings"/></remarks>
-        public static void SetAppSettings(NameValueCollection appSettings) => ConfigFieldValues.ForEach(field => field?
-            .GetType()
-            .GetRuntimeMethod("SetAppSettings",
-                              new[] { typeof(NameValueCollection), })
-            .Invoke(field, new object[] { appSettings, }));
+        public static void SetAppSettings(NameValueCollection appSettings) => ConfigFields
+                                                                              .Select(x => x.GetValue(null) as
+                                                                                  IConfigSetting)
+                                                                              .ToList()
+                                                                              .ForEach(
+                                                                                  field => field.SetAppSettings(
+                                                                                      appSettings));
 
         private static List<FieldInfo> ConfigFields => typeof(T).GetRuntimeFields()
                                                                 .Where(fieldInfo =>
@@ -60,7 +62,5 @@ namespace AppConfigSettings
                                                                                .IsAssignableFrom(fieldInfo.FieldType) &&
                                                                            fieldInfo.GetValue(null) != null)
                                                                 .ToList();
-
-        private static List<object> ConfigFieldValues => ConfigFields.Select(x => x.GetValue(null)).ToList();
     }
 }

--- a/src/SettingsBase.cs
+++ b/src/SettingsBase.cs
@@ -11,37 +11,12 @@ namespace AppConfigSettings
     {
         private const string CONFIG_SETTING_VALUE = "Get";
 
-        protected SettingsBase() => ConfigFields.ForEach(fieldInfo =>
-                                                         {
-                                                             var field = fieldInfo.GetValue(null) as IConfigSetting;
-                                                             var fieldType = field?.GetType();
-
-                                                             if (fieldType == null)
-                                                             {
-                                                                 return;
-                                                             }
-
-                                                             var key = ConfigFields
-                                                                       .Where(x => x.FieldHandle ==
-                                                                                  fieldInfo.FieldHandle)
-                                                                       .Select(x => x.Name)
-                                                                       .First();
-
-                                                             if (key == null ||
-                                                                 ContainsKey(key))
-                                                             {
-                                                                 return;
-                                                             }
-
-                                                             var getMethod = fieldType
-                                                                 .GetRuntimeMethod(CONFIG_SETTING_VALUE,
-                                                                     new[] { typeof(bool), });
-
-                                                             object[] paramArray = { true, };
-                                                             var val = getMethod?.Invoke(field, paramArray);
-
-                                                             Add(key, val);
-                                                         });
+        protected SettingsBase() => ConfigFields.ForEach(configFieldInfo => Add(configFieldInfo.Info.Name,
+                                                             configFieldInfo.Value.GetType()
+                                                                            .GetRuntimeMethod(CONFIG_SETTING_VALUE,
+                                                                                new[] { typeof(bool), })
+                                                                            ?.Invoke(configFieldInfo.Value,
+                                                                                new object[] { true, })));
 
         /// <summary>
         /// Sets the application settings to override the default.
@@ -49,18 +24,15 @@ namespace AppConfigSettings
         /// <param name="appSettings">The application settings.</param>
         /// <remarks>Default AppSettings is <see cref="ConfigurationManager.AppSettings"/></remarks>
         public static void SetAppSettings(NameValueCollection appSettings) => ConfigFields
-                                                                              .Select(x => x.GetValue(null) as
-                                                                                  IConfigSetting)
-                                                                              .ToList()
-                                                                              .ForEach(
-                                                                                  field => field.SetAppSettings(
-                                                                                      appSettings));
+            .ForEach(configFieldInfo => configFieldInfo.Value.SetAppSettings(appSettings));
 
-        private static List<FieldInfo> ConfigFields => typeof(T).GetRuntimeFields()
-                                                                .Where(fieldInfo =>
-                                                                           typeof(IConfigSetting)
-                                                                               .IsAssignableFrom(fieldInfo.FieldType) &&
-                                                                           fieldInfo.GetValue(null) != null)
-                                                                .ToList();
+        private static List<ConfigFieldInfo> ConfigFields => typeof(T).GetRuntimeFields()
+                                                                      .Where(fieldInfo =>
+                                                                                 typeof(IConfigSetting)
+                                                                                     .IsAssignableFrom(
+                                                                                         fieldInfo.FieldType) &&
+                                                                                 fieldInfo.GetValue(null) != null)
+                                                                      .Select(x => new ConfigFieldInfo(x))
+                                                                      .ToList();
     }
 }

--- a/src/SettingsBase.cs
+++ b/src/SettingsBase.cs
@@ -10,7 +10,6 @@ namespace AppConfigSettings
     public abstract class SettingsBase<T> : Dictionary<string, object> where T : class, new()
     {
         private const string CONFIG_SETTING_VALUE = "Get";
-        private const string CONFIG_SETTING_CONFIG = "AppConfig";
 
         protected SettingsBase() => ConfigFields.ForEach(fieldInfo =>
                                                          {
@@ -51,8 +50,9 @@ namespace AppConfigSettings
         /// <remarks>Default AppSettings is <see cref="ConfigurationManager.AppSettings"/></remarks>
         public static void SetAppSettings(NameValueCollection appSettings) => ConfigFieldValues.ForEach(field => field?
             .GetType()
-            .GetRuntimeProperty(CONFIG_SETTING_CONFIG)
-            ?.SetValue(field, appSettings));
+            .GetRuntimeMethod("SetAppSettings",
+                              new[] { typeof(NameValueCollection), })
+            .Invoke(field, new object[] { appSettings, }));
 
         private static List<FieldInfo> ConfigFields => typeof(T).GetRuntimeFields()
                                                                 .Where(fieldInfo =>


### PR DESCRIPTION
Remove AppConfig setting from ConfigSetting public interface.
Add SetAppSettings(NameValueCollection appSettings) to ConfigSetting public interface.
Add Missing ThrowOnException code.
Add Action ProcessSettingValue to process data based on found value.
Example:
  
            setting.ProcessSettingValue = selectedSetting =>
                                            {
                                                testInt = selectedSetting.Value + 3;
                                                testKey = selectedSetting.Key;

                                                return selectedSetting.Key == "foo";
                                            };